### PR TITLE
redirecting back to course after user requests membership

### DIFF
--- a/Modules/Course/classes/class.ilCourseRegistrationGUI.php
+++ b/Modules/Course/classes/class.ilCourseRegistrationGUI.php
@@ -337,7 +337,7 @@ class ilCourseRegistrationGUI extends ilRegistrationGUI
                     $sub_data = $this->participants->getSubscriberData($ilUser->getId());
                     $sub->setValue($sub_data['subject']);
                     $sub->setInfo('');
-                    ilUtil::sendFailure($this->lng->txt('crs_reg_user_already_subscribed'));
+                    ilUtil::sendInfo($this->lng->txt('crs_reg_user_already_subscribed'));
                     $this->enableRegistration(false);
                 }
                 $txt->addSubItem($sub);
@@ -481,12 +481,8 @@ class ilCourseRegistrationGUI extends ilRegistrationGUI
                 $this->participants->sendNotification($this->participants->NOTIFY_SUBSCRIPTION_REQUEST, $ilUser->getId());
                 
                 ilUtil::sendSuccess($this->lng->txt("application_completed"), true);
-                $ilCtrl->setParameterByClass(
-                    "ilrepositorygui",
-                    "ref_id",
-                    $tree->getParentId($this->container->getRefId())
-                );
-                $ilCtrl->redirectByClass("ilrepositorygui", "");
+                $ilCtrl->setParameterByClass(self::class, 'ref_id', $this->container->getRefId());
+                $ilCtrl->redirect($this, "show");
                 break;
             
             default:

--- a/Modules/Group/classes/class.ilGroupRegistrationGUI.php
+++ b/Modules/Group/classes/class.ilGroupRegistrationGUI.php
@@ -488,12 +488,8 @@ class ilGroupRegistrationGUI extends ilRegistrationGUI
                 );
 
                 ilUtil::sendSuccess($this->lng->txt("application_completed"), true);
-                $ilCtrl->setParameterByClass(
-                    "ilrepositorygui",
-                    "ref_id",
-                    $tree->getParentId($this->container->getRefId())
-                );
-                $ilCtrl->redirectByClass("ilrepositorygui", "");
+                $ilCtrl->setParameterByClass(self::class, 'ref_id', $this->container->getRefId());
+                $ilCtrl->redirect($this, "show");
                 break;
             
             default:

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -4968,7 +4968,7 @@ crs#:#crs_print_list#:#Generate List
 crs#:#crs_reg_max_info#:#Define the maximum number of users that can be assigned to this course.
 crs#:#crs_reg_subject#:#Message
 crs#:#crs_reg_until#:#Registration Period
-crs#:#crs_reg_user_already_subscribed#:#You have already requested membership for this course
+crs#:#crs_reg_user_already_subscribed#:#Waiting for approval of registration request
 crs#:#crs_reg#:#Registration Settings
 crs#:#crs_registration_deactivated#:#Only course administrators can add users to the course.
 crs#:#crs_registration_limited#:#Limited Registration Period
@@ -5657,7 +5657,7 @@ grp#:#crs_grp_no_courses_assigned#:#No Groups Assigned
 grp#:#grouping_change_assignment#:#Change Assignment
 grp#:#grp_added_to_list#:#You have been assigned to the waiting list of group "%s". You are assigned to position %s on the waiting list.
 grp#:#grp_admins#:#Administrators
-grp#:#grp_already_assigned#:#You have already requested membership for this group.
+grp#:#grp_already_assigned#:#Waiting for approval of registration request.
 grp#:#grp_cancel_subscr_request#:#Delete Membership Request
 grp#:#grp_change_type#:#Change Group Type
 didactic#:#grp_closed_info#:#Group is not visible for non-members.

--- a/lang/ilias_fr.lang
+++ b/lang/ilias_fr.lang
@@ -6865,7 +6865,7 @@ crs#:#crs_reg_no_selfreg#:#Pas d'auto-inscription
 crs#:#crs_reg_password_info#:#Les utilisateurs doivent entrer ce mot de passe pour s'inscrire à ce cours.
 crs#:#crs_reg_subject#:#Message
 crs#:#crs_reg_until#:#Période d'Inscription
-crs#:#crs_reg_user_already_subscribed#:#Vous vous êtes déjà fait une demande d'inscription à ce cours
+crs#:#crs_reg_user_already_subscribed#:#En attente d'approbation de la demande d'inscription
 crs#:#crs_registration#:#Inscription au Cours
 crs#:#crs_registration_confirmation_info#:#Les utilisateurs concernés peuvent envoyer une requête/un message aux administrateurs de cours.
 crs#:#crs_registration_deactivated#:#Sélectionner cette option pour désactiver l'inscription. Aucun utilisateur ne pourra s'inscrire.
@@ -8819,7 +8819,7 @@ grp#:#grp_admission_link_success_registration#:#Groupe "%s" enregistré avec suc
 grp#:#grp_agree#:#Acceptation
 grp#:#grp_agreement_header#:#Agrément de l'utilisateur
 grp#:#grp_agreement_required#:#Vous devez accepter l'agrément de l'utilisateur, si vous désirez accéder au contenu du groupe.
-grp#:#grp_already_assigned#:#Vous avez déjà  demandé une adhésion pour ce groupe.
+grp#:#grp_already_assigned#:#En attente d'approbation de la demande d'inscription.
 grp#:#grp_at_least_one_admin#:#Il doit y avoir au moins un administrateur de groupe.
 grp#:#grp_cancel_subscr_request#:#Supprimer requête d'adhésion
 grp#:#grp_cancellation_end#:#Limite d'Annulation


### PR DESCRIPTION
Instead of redirecting back to the repository after a registration request, the user is redirected back to the course page with an updated message.