### PR TITLE
moving my courses and groups to the top of the Dashboard page

### DIFF
--- a/Services/Dashboard/classes/class.ilDashboardGUI.php
+++ b/Services/Dashboard/classes/class.ilDashboardGUI.php
@@ -810,16 +810,17 @@ class ilDashboardGUI
         $tpl = new ilTemplate("tpl.dashboard.html", true, true, "Services/Dashboard");
         $settings = new ilPDSelectedItemsBlockViewSettings($this->user);
 
+        if ($settings->enabledMemberships()) {
+            $html = $this->renderMemberships();
+        }
+
         if ($settings->enabledSelectedItems()) {
-            $html = $this->renderFavourites();
+            $html .= $this->renderFavourites();
         }
         $html .= $this->renderRecommendedContent();
         $html .= $this->renderStudyProgrammes();
         $html .= $this->renderLearningSequences();
-        if ($settings->enabledMemberships()) {
-            $html .= $this->renderMemberships();
-        }
-
+        
         $tpl->setVariable("CONTENT", $html);
 
         return $tpl->get();


### PR DESCRIPTION
Moving the My Courses and Groups section to the top of the Dashboard page.