### PR TITLE
adding ability to use wildcards in cloze and text questions and allow…

### DIFF
--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -103,8 +103,7 @@ ilias.questions.checkAnswers = function(a_id) {
 	answers[a_id].tries++;
 
 	var call = "ilias.questions."+questions[a_id].type+"("+a_id+")";
-	console.log(call);
-
+	
 	eval(call);
 
 	if (typeof il.LearningModule != "undefined") {
@@ -1845,4 +1844,3 @@ function getFname(yStr){
 }
 
 answers = ilias.questions.answers;
-console.dir(answers);

--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -1220,7 +1220,7 @@ ilias.questions.showCorrectAnswers =function(a_id) {
 							cvalue = questions[a_id].gaps[i].item[j].value;
 						}
 					}
-					jQuery('input#'+a_id+"_"+i).val(cvalue);
+					//jQuery('input#'+a_id+"_"+i).val(cvalue);
 					jQuery('input#'+a_id+"_"+i).prop("disabled",true);
 				}
 			}

--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -565,29 +565,61 @@ ilias.questions.assTextSubset = function(a_id) {
 		var found = false;
 		for (var c=0;c<questions[a_id].correct_answers.length;c++)
 		{
-			var correct_answer = questions[a_id].correct_answers[c]["answertext"];
-			if(questions[a_id].matching_method == "ci")
-			{
-				correct_answer = correct_answer.toLowerCase();
-			}
-			if(correct_answer == answer && questions[a_id].correct_answers[c]["points"] > 0)
-			{
-				found = true;
-
-				// check if answer was given multiple times
-				for (var j=0;j<i;j++) {
-					var old_answer = a_node.get(j).value;
-					if(questions[a_id].matching_method == "ci")
-					{
-						old_answer = old_answer.toLowerCase();
+			if(questions[a_id].correct_answers[c]["answertext"].indexOf("|")){
+				var alt_words = questions[a_id].correct_answers[c]["answertext"].split("|");
+				alt_words.forEach((element) => {
+					element = element.trim();
+					var pattern = element.replaceAll("*", ".*");
+					pattern = "^"+pattern+"$";
+					pattern =  new RegExp(pattern);
+					if(questions[a_id].matching_method == "ci"){
+						element = element.toLowerCase();
 					}
-					if(old_answer == answer)
+					if(element == answer || pattern.test(answer) && questions[a_id].correct_answers[c]["points"] > 0)
 					{
-						found = false;
-						j = i;
+						found = true;
+
+						// check if answer was given multiple times
+						for (var j=0;j<i;j++) {
+							var old_answer = a_node.get(j).value;
+							if(questions[a_id].matching_method == "ci")
+							{
+								old_answer = old_answer.toLowerCase();
+							}
+							if(old_answer == answer)
+							{
+								found = false;
+								j = i;
+							}
+						}
+					}
+				});
+			}else{
+				var correct_answer = questions[a_id].correct_answers[c]["answertext"];
+				if(questions[a_id].matching_method == "ci")
+				{
+					correct_answer = correct_answer.toLowerCase();
+				}
+				if(correct_answer == answer && questions[a_id].correct_answers[c]["points"] > 0)
+				{
+					found = true;
+
+					// check if answer was given multiple times
+					for (var j=0;j<i;j++) {
+						var old_answer = a_node.get(j).value;
+						if(questions[a_id].matching_method == "ci")
+						{
+							old_answer = old_answer.toLowerCase();
+						}
+						if(old_answer == answer)
+						{
+							found = false;
+							j = i;
+						}
 					}
 				}
 			}
+			
 		}
 		if(found === false)
 		{
@@ -881,7 +913,10 @@ ilias.questions.showFeedback =function(a_id) {
 			questions[a_id].nr_of_tries - answers[a_id].tries > 0) {
 			txt_wrong_answers = '';
 		}
-		ilias.questions.txt.all_answers_correct = questions[a_id].feedback['correct'];
+		if(questions[a_id].feedback['correct']){
+			ilias.questions.txt.all_answers_correct = questions[a_id].feedback['correct'];
+		}
+
 	}
 	else
 	{
@@ -1311,7 +1346,7 @@ ilias.questions.showCorrectAnswers =function(a_id) {
 				}
 				if(found === false)
 				{
-					jQuery(a_node[i]).val("");
+					//jQuery(a_node[i]).val("");
 				}
 			}
 			var correct_info = "";

--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -103,9 +103,9 @@ ilias.questions.checkAnswers = function(a_id) {
 	answers[a_id].tries++;
 
 	var call = "ilias.questions."+questions[a_id].type+"("+a_id+")";
+	console.log(call);
 
 	eval(call);
-
 
 	if (typeof il.LearningModule != "undefined") {
 		il.LearningModule.processAnswer(ilias.questions);
@@ -298,8 +298,22 @@ ilias.questions.assTextQuestion = function(a_id) {
 		case 'one':
 			for (var i = 0; i < words.length; i++) {
 				for(var j = 0; j < questions[a_id].answers.length; j++){
-					if( words[i] === questions[a_id].answers[j].text ){
-						passed = true;
+					var option = questions[a_id].answers[j].text;
+					if(option.indexOf("|")){
+						var alt_words = option.split("|");
+						alt_words.forEach((element) => {
+						    var pattern = "^"+element.trim()+"$";
+						    pattern = pattern.replaceAll("*", ".*");
+							pattern =  new RegExp(pattern);
+						    if( words[i] === element.trim() || pattern.test(words[i])){
+						    	passed = true;
+						    }
+						});
+					}else{
+						var pattern = new RegExp(questions[a_id].answers[j].text);
+						if( words[i] === questions[a_id].answers[j].text || pattern.test(words[i]) ){
+							passed = true;
+						}
 					}
 				}
 			}
@@ -602,7 +616,10 @@ ilias.questions.assClozeTest = function(a_id) {
 			if (type==0) {
 				for(var j=0;j<questions[a_id].gaps[i].item.length;j++)
 				{
-					if (questions[a_id].gaps[i].item[j].value == a_node.value) {
+					var pattern = questions[a_id].gaps[i].item[j].value.replaceAll("*", ".*");
+					pattern = "^"+pattern+"$";
+					pattern =  new RegExp(pattern);
+					if (questions[a_id].gaps[i].item[j].value == a_node.value || pattern.test(a_node.value)) {
 						value_found=true;
 						if (questions[a_id].gaps[i].item[j].points <= 0) {
 							answers[a_id].passed = false;
@@ -1828,3 +1845,4 @@ function getFname(yStr){
 }
 
 answers = ilias.questions.answers;
+console.dir(answers);

--- a/Modules/Scorm2004/scripts/questions/question_handling.js
+++ b/Modules/Scorm2004/scripts/questions/question_handling.js
@@ -318,19 +318,47 @@ ilias.questions.assTextQuestion = function(a_id) {
 			}
 			break;
 		case 'all':
-			var tst_arr = [];
-			for(var i = 0; i < questions[a_id].answers.length; i++){
-				if(questions[a_id].text_rating === 'ci'){
-					tst_arr.push(questions[a_id].answers[i].text.toLowerCase());
-				} else {
-					tst_arr.push(questions[a_id].answers[i].text);
-				}
-			}
-			if(tst_arr.filter(function(i) {return words.indexOf(i) < 0;}).length === 0){
-				passed = true;
-			}
-			break;
-
+	    	var tst_arr = [];
+	      	for(var i = 0; i < questions[a_id].answers.length; i++){
+	        	if(questions[a_id].text_rating === 'ci'){
+		          	if(questions[a_id].answers[i].text.indexOf("|")){
+		            	var alt_words = questions[a_id].answers[i].text.split("|").map(x => x.toLowerCase());
+		            	tst_arr.push(alt_words);
+		          	} else {
+		            	tst_arr.push(questions[a_id].answers[i].text.toLowerCase());
+		          	}
+	        	} else {
+	       			if(questions[a_id].answers[i].text.indexOf("|")){
+	            		var alt_words = questions[a_id].answers[i].text.split("|");
+	            		tst_arr.push(alt_words);
+	          		} else {
+	            		tst_arr.push(questions[a_id].answers[i].text);
+	          		}
+	        	}
+	    	}
+	    	let correct_arr = []
+	      	tst_arr.forEach(function(i) { 
+	        //foreach array of words that need to have at least (1) completed in the group.
+		        i.forEach( (element) => {
+		        	var pattern = "^"+element.trim()+"$";
+		          	pattern = pattern.replaceAll("*", ".*");
+		          	pattern =  new RegExp(pattern);
+		          	
+		          	//foreach word
+		          	words.forEach((word) => {
+		            
+		            	//if the word is in the list of words (words array)
+		            	if(pattern.test(word)) {
+		            		tst_arr[i];
+		              		correct_arr.push(i);
+		              		return true;
+		            	}
+		        	});  
+		        });
+		        return true;
+	    	});
+	    passed = JSON.stringify(correct_arr) == JSON.stringify(tst_arr);
+	    break;
 	}
 	answers[a_id].passed = passed;
 	ilias.questions.showFeedback(a_id);
@@ -1220,7 +1248,7 @@ ilias.questions.showCorrectAnswers =function(a_id) {
 							cvalue = questions[a_id].gaps[i].item[j].value;
 						}
 					}
-					jQuery('input#'+a_id+"_"+i).val(cvalue);
+					//jQuery('input#'+a_id+"_"+i).val(cvalue);
 					jQuery('input#'+a_id+"_"+i).prop("disabled",true);
 				}
 			}

--- a/Modules/TestQuestionPool/classes/Form/class.ilClozeGapInputBuilderGUI.php
+++ b/Modules/TestQuestionPool/classes/Form/class.ilClozeGapInputBuilderGUI.php
@@ -244,6 +244,7 @@ class ilClozeGapInputBuilderGUI extends ilSubEnabledFormPropertyGUI
         $custom_template->setVariable('COPY', $lng->txt('copy_of'));
         $custom_template->setVariable('OK', $lng->txt('ok'));
         $custom_template->setVariable('CANCEL', $lng->txt('cancel'));
+        $custom_template->setVariable('WILDCARD', $lng->txt('cloze_wildcard'));
         $custom_template->setVariable('WHITESPACE_FRONT', $lng->txt('cloze_textgap_whitespace_before'));
         $custom_template->setVariable('WHITESPACE_BACK', $lng->txt('cloze_textgap_whitespace_after'));
         $custom_template->setVariable('WHITESPACE_MULTIPLE', $lng->txt('cloze_textgap_multiple_whitespace'));

--- a/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilAnswerWizardInputGUI.php
@@ -329,6 +329,7 @@ class ilAnswerWizardInputGUI extends ilTextInputGUI
         $tpl->setVariable("ANSWER_TEXT", $this->getTextInputLabel($lng));
         $tpl->setVariable("POINTS_TEXT", $this->getPointsInputLabel($lng));
         $tpl->setVariable("COMMANDS_TEXT", $lng->txt('actions'));
+        $tpl->setVariable("WILDCARD", $lng->txt('essay_wildcard_alternate'));
 
         $a_tpl->setCurrentBlock("prop_generic");
         $a_tpl->setVariable("PROP_GENERIC", $tpl->get());

--- a/Modules/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
+++ b/Modules/TestQuestionPool/classes/class.ilEssayKeywordWizardInputGUI.php
@@ -145,6 +145,7 @@ class ilEssayKeywordWizardInputGUI extends ilSingleChoiceWizardInputGUI
         $tpl->setVariable("DELETE_IMAGE_QUESTION", $lng->txt('delete_image_question'));
         $tpl->setVariable("ANSWER_TEXT", $lng->txt('answer_text'));
         $tpl->setVariable("POINTS_TEXT", $lng->txt('points'));
+        $tpl->setVariable("WILDCARD", $lng->txt('essay_wildcard_alternate'));
         $tpl->setVariable("COMMANDS_TEXT", $lng->txt('actions'));
         $tpl->setVariable("POINTS_CHECKED_TEXT", $lng->txt('checkbox_checked'));
 

--- a/Modules/TestQuestionPool/templates/default/cloze_gap_builder.js
+++ b/Modules/TestQuestionPool/templates/default/cloze_gap_builder.js
@@ -1099,6 +1099,7 @@ var ClozeGapBuilder = (function () {
 
 		if (ClozeSettings.gaps_php[0][pos]) {
 			$('.modal-body').html('');
+			$('.modal-body').html('<span>'+ClozeSettings.wildcard+'</span>');
 			if (ClozeGlobals.jour_fixe_incompatible === false) {
 				ClozeSettings.gap_backup = JSON.parse(JSON.stringify({
 					'id':   pos,

--- a/Modules/TestQuestionPool/templates/default/tpl.il_as_cloze_gap_builder.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.il_as_cloze_gap_builder.html
@@ -83,7 +83,8 @@
         gap_in_more_than_one: "{GAP_IS_USED_MORE_THAN_ONE_COMB}",
         gap_text            : "{GAP}",
         ok_text             : "{OK}",
-        cancel_text         : "{CANCEL}"
+        cancel_text         : "{CANCEL}",
+        wildcard            : "{WILDCARD}"
     };
 </script>
 <script type='text/javascript' src='./Modules/TestQuestionPool/templates/default/cloze_gap_builder.js'></script>

--- a/Modules/TestQuestionPool/templates/default/tpl.prop_answerwizardinput.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.prop_answerwizardinput.html
@@ -1,4 +1,5 @@
 <div class="form-inline" id="{ELEMENT_ID}">
+	{WILDCARD}
 	<table class="answerwizard table table-condensed table-striped">
 		<thead>
 			<tr>

--- a/Modules/TestQuestionPool/templates/default/tpl.prop_essaykeywordswizardinput.html
+++ b/Modules/TestQuestionPool/templates/default/tpl.prop_essaykeywordswizardinput.html
@@ -1,4 +1,5 @@
 <div class="form-inline" id="{ELEMENT_ID}">
+	{WILDCARD}
 	<table class="multiplechoicewizard table table-condensed table-striped">
 		<thead>
 			<tr>

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -619,6 +619,7 @@ assessment#:#essay_scoring_mode_keyword_relation_all#:#Automatic Scoring with Ke
 assessment#:#essay_scoring_mode_keyword_relation_all_desc#:#The points are granted automatically, if all keywords are found.
 assessment#:#essay_scoring_mode_keyword_relation_one#:#Automatic Scoring with Keywords on Finding ONE
 assessment#:#essay_scoring_mode_keyword_relation_one_desc#:#The points are granted automatically, if at least one keyword is found.
+assessment#:#essay_wildcard_alternate#:#Wildcards (*) May also be used to denote multiple spelling options. A wildcard prefix allows multiple characters to be added before a word only, a suffix allows additional characters at the end of a word and a wildcard internally allows additional characters inside a word. They can be combined if desired. To enter multiple alternate answer texts, please seperate them with the | character. 
 assessment#:#mark_schema_invalid#:#The mark schema does not validate. Please create a correct schema.
 assessment#:#assessment_scoring_adjust#:#Enable corrections
 assessment#:#assessment_scoring_adjust_desc#:#Enables the corrections feature to allow modifications to questions in a test.
@@ -760,6 +761,7 @@ assessment#:#qpl_numeric_lower_needs_valid_lower_alert#:#The lower bound needs t
 assessment#:#qpl_numeric_upper_needs_valid_upper_alert#:#The upper bound needs to be valid numerical value greater than the lower bound.
 assessment#:#cloze_fixed_textlength#:#Text Field Length
 assessment#:#cloze_text#:#Cloze Text
+assessment#:#cloze_wildcard#:#Wildcards (*) May also be used to denote multiple spelling options. A wildcard prefix allows multiple characters to be added before a word only, a suffix allows additional characters at the end of a word and a wildcard internally allows additional characters inside a word. They can be combined if desired. 
 assessment#:#cloze_textgap_case_insensitive#:#Case Insensitive
 assessment#:#cloze_textgap_case_sensitive#:#Case Sensitive
 assessment#:#cloze_textgap_levenshtein_of#:#Levenshtein Distance of %s


### PR DESCRIPTION
…ing multiple options on essay qs with seperation of |

The option to add a wildcard option to a word would allow users to enter l’immerger s’immerger, immerger, d’immerger and have all be accepted correct answers. This will allow technically right answers with differentiating spelling and grammatical options. Some people, for example, might enter color somewhere and if the accepted value is “colour” it would mark this correct answer wrong. The wildcard could be added to allow the question to mark both correct. wild cars can be any where in the word and there can be multiple. 

This is added to cloze and essays. 

Also adds ability to add alternate options for essay questions with automatic scoring. The admin just adds answer | answer in the answer text. Options are split by "|"