### PR TITLE
Adds missing rubric language files

### DIFF
--- a/Customizing/global/lang/ilias_en.lang.local
+++ b/Customizing/global/lang/ilias_en.lang.local
@@ -52,7 +52,8 @@ trac#:#no_current_rubric_grade#:#No Current Rubric Grade.
 trac#:#rubric_option_export_graded_pdf#:#Export Graded PDF
 trac#:#rubric_card_not_completed#:#Rubric Card is Incomplete.
 trac#:#rubric_card_please_complete#:#Please Click Here to Continue Editing Rubric Card
-common#:#authenticate_ilias#:#Non-REALTOR&#174;
+trac#:#rubric_exercise_graded#:#Rubric Graded: 
+trac#:#rubric_is_now_available#:#is now available.
 common#:#login_to_ilias#:#Login
 pwassist#:#password_assistance#:#Password and Username Assistance
 pwassist#:#pwassist_mail_body#:#You (or someone at %3$s) have requested password assistance for the user account "%4$s".\n\nTo reset your password, please:\n\n1. Click the link or enter the following address in your browser: \n%6$s\n\nImportant: The address is a single line. If you see this address split into multiple lines, then your e-mail program has inserted these line breaks.\n\n2. Enter your username and a new password.  Click Submit.\n\nFor security reasons, you can only perform this action once. The link will only remain active for a limited time before it becomes invalid.\n\nPlease note:\n\n- If you have made this request by accident: Delete this mail.\n\n- If you did not request password assistance: Please contact: %5$s.\n\n***************************************


### PR DESCRIPTION
While working on a rubric related item ,realized rubrics don't have the text data in the email notifications.

also removed 'Non-Realtor' from language because that was a stayover from old ilias for Revia.