### PR TITLE
Removes the Ilias logo from the default mail template

### DIFF
--- a/Services/Mail/templates/default/tpl.html_mail_template.html
+++ b/Services/Mail/templates/default/tpl.html_mail_template.html
@@ -1,16 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<meta name="viewport" content="width=device-width" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width" />
 </head>
 <body style="margin: 0px;">
-<table style="background-color: #D0D0D0; width: 100%;">
-	<tr>
-		<td style="padding-left: 15px;"><img src="cid:img/ilias_logo.jpg" alt="ILIAS-Logo" /></td>
-		<td style="padding-left: 15px; padding-right: 15px; font-family: 'Open Sans', 'Verdana', 'Arial', 'Helvetica', sans-serif; font-weight: normal; color: #ffffff; text-align: left; line-height: 19px; font-size: 20px;">Open Source e-Learning</td>
-	</tr>
-</table>
 <div style="margin: 15px; font-family: 'Open Sans', 'Verdana', 'Arial', 'Helvetica', sans-serif; font-weight: normal; text-align: left; line-height: 19px; font-size: 14px;">{PLACEHOLDER}</div>
 </body>
 </html>


### PR DESCRIPTION
Instead of adding a new template to all skins, it makes sense to remove the ilias logo from the default mail template so that we can enable html frames on mail in all portals for the link checker.

(https://taiga.cpkn.ca/project/evanjackson-tasks-and-issues-april-2022-march-2023/issue/715)