### PR TITLE
using the system admin email address from database when constructing …

### DIFF
--- a/Modules/SystemFolder/classes/class.ilAccessibilitySupportContactsGUI.php
+++ b/Modules/SystemFolder/classes/class.ilAccessibilitySupportContactsGUI.php
@@ -121,10 +121,15 @@ class ilAccessibilitySupportContactsGUI
             isset($http->request()->getServerParams()['HTTPS'])
             && $http->request()->getServerParams()['HTTPS'] !== 'off'
             ? 'https' : 'http';
+
         $url = $request_scheme . '://'
             . $http->request()->getServerParams()['HTTP_HOST']
             . $http->request()->getServerParams()['REQUEST_URI'];
-        return "mailto:support@cpkn.ca?subject=Support%20Request&body=*%20*%20*%0D%0A" . CLIENT_ID . "%20%3D%0D%0A" . rawurlencode($url) . "%20%3D";
+
+        $admin_email = $DIC->settings()->get("admin_email", "support@cpkn.ca");
+        $client_id = CLIENT_ID;
+        $encoded_url = rawurlencode($url);
+        return "mailto:$admin_email?subject=Support%20Request&body=%0D%0A%0D%0A***%0D%0A$client_id%0D%0A$encoded_url%20";
     }
 
     /**

--- a/Modules/SystemFolder/classes/class.ilSystemSupportContactsGUI.php
+++ b/Modules/SystemFolder/classes/class.ilSystemSupportContactsGUI.php
@@ -98,7 +98,10 @@ class ilSystemSupportContactsGUI
             . $http->request()->getServerParams()['HTTP_HOST']
             . $http->request()->getServerParams()['REQUEST_URI'];
 
-        return "mailto:support@cpkn.ca?subject=Support%20Request&body=*%20*%20*%0D%0A" . CLIENT_ID . "%20%3D%0D%0A" . rawurlencode($url) . "%20%3D";
+        $admin_email = $DIC->settings()->get("admin_email", "support@cpkn.ca");
+        $client_id = CLIENT_ID;
+        $encoded_url = rawurlencode($url);
+        return "mailto:$admin_email?subject=Support%20Request&body=%0D%0A%0D%0A***%0D%0A$client_id%0D%0A$encoded_url%20";
     }
 
     /**


### PR DESCRIPTION
…mailto footer link. This should make it so the proper support email (@cpkn, @pskn) is linked depending on the portal. 