### PR TITLE
Allow users in the group of the directory creator to modify that group.

### DIFF
--- a/src/Filesystem/Provider/Configuration/LocalConfig.php
+++ b/src/Filesystem/Provider/Configuration/LocalConfig.php
@@ -103,7 +103,7 @@ final class LocalConfig
         string $rootPath,
         int $fileAccessPublic = 0744,
         int $fileAccessPrivate = 0700,
-        int $directoryAccessPublic = 0755,
+        int $directoryAccessPublic = 0775,
         int $directoryAccessPrivate = 0700,
         int $lockMode = LOCK_EX,
         int $linkBehaviour = self::SKIP_LINKS


### PR DESCRIPTION
Move from a+rwx,g-w,o-w permissions to a+rwx,o-w

This will also have to coincide with a chmod -Rf 0775 on /var/data/ilias and /var/www/ilias/data