### PR TITLE
Gradebook fixes 

### DIFF
--- a/Customizing/global/lang/ilias_en.lang.local
+++ b/Customizing/global/lang/ilias_en.lang.local
@@ -92,6 +92,9 @@ trac#:#gradebook_average#:#Average Grade
 trac#:#gradebook_overall_status#:#Student Overall Status
 trac#:#gradebook_average_progress#:#Average Progress
 trac#:#gradebook_passing_grade#:#Passing Grade
+trac#:#gradebook_mark_gradebook#:#Item can be marked directly in the gradebook
+trac#:#gradebook_mark_children#:#Learning progress is deteremined by its children
+trac#:#gradebook_mark_automated#:#Learning progress is set in the item itself
 trac#:#itgr#:#Item Group
 pwassist#:#pwassist_unknown_username_or_email#:#Could not process password assistance form (reason: no user found) %s / %s
 pwassist#:#pwassist_unknown_username_or_email#:#Could not process password assistance form (reason: no user found) %s / %s

--- a/Customizing/global/lang/ilias_en.lang.local
+++ b/Customizing/global/lang/ilias_en.lang.local
@@ -91,6 +91,7 @@ trac#:#gradebook_completed#:#Completed
 trac#:#gradebook_average#:#Average Grade
 trac#:#gradebook_overall_status#:#Student Overall Status
 trac#:#gradebook_average_progress#:#Average Progress
+trac#:#gradebook_passing_grade#:#Passing Grade
 trac#:#itgr#:#Item Group
 pwassist#:#pwassist_unknown_username_or_email#:#Could not process password assistance form (reason: no user found) %s / %s
 pwassist#:#pwassist_unknown_username_or_email#:#Could not process password assistance form (reason: no user found) %s / %s

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookCTRL.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookCTRL.php
@@ -12,7 +12,7 @@ switch ($_POST['action'])
         try{
             $obj_id = ilObject::_lookupObjectId($_POST['ref_id']);
             $gradebookObj=new ilLPGradebookWeight($obj_id);
-            $result = $gradebookObj->saveGradebookWeight($_POST['nodes']);
+            $result = $gradebookObj->saveGradebookWeight($_POST['nodes'], $_POST['passing_grade']);
             echo json_encode(['status'=>'success','data'=>$result]);
         }catch(Exception $e){
             echo json_encode(['status'=>'failure','message'=>$e->getMessage()]);

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookGrade.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookGrade.php
@@ -495,7 +495,9 @@ class ilLPGradebookGrade extends ilLPGradebook
     {
         $gradebook_objects = $this->getUsersGrades($usr_id);
         $overall = $this->getOverallUserGrades($usr_id);
+        $revision = $this->getUsersLatestRevision($usr_id);
         $data = [
+            'passing_grade' => $revision->getPassingGrade(),
             'overall' => $overall,
             'grade_objects' => $gradebook_objects
         ];

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookGrade.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookGrade.php
@@ -303,7 +303,7 @@ class ilLPGradebookGrade extends ilLPGradebook
         //if the learning progress is done in the object itself grab the marks from there.
         if ($revision_object['lp_type'] == 0) {
             $mark = ilLPMarks::_lookupMark($usr_id, $revision_object['obj_id']);
-            $mark = ($mark == 0 || is_null($mark) || empty($mark)) ? 0 : $mark;
+            $mark = ($mark == 0 || is_null($mark) || empty($mark)) ? 100 : $mark;
             $adjusted = $mark * ($revision_object['object_weight'] * 0.01);
         } else {
             $gradebook_grade = array_shift(ilGradebookGradesConfig::where([
@@ -316,7 +316,7 @@ class ilLPGradebookGrade extends ilLPGradebook
             $adjusted = ($gradebook_grade['actual_grade'] == 0 ||
                 is_null($gradebook_grade['actual_grade']) ||
                 empty($gradebook_grade['actual_grade']))
-                ? 0 * ($revision_object['object_weight'] * 0.01) : $gradebook_grade['adjusted_grade'];
+                ? 100 * ($revision_object['object_weight'] * 0.01) : $gradebook_grade['adjusted_grade'];
         }
         return $adjusted;
     }

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookGrade.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookGrade.php
@@ -419,7 +419,6 @@ class ilLPGradebookGrade extends ilLPGradebook
             $usr_id
         );
 
-
         $adjusted_grade = (int)$actual_grade * ($gradebook_object['object_weight'] * 0.01);
 
         //determine whether we should update or not.
@@ -435,7 +434,8 @@ class ilLPGradebookGrade extends ilLPGradebook
                 $update = true;
             }
         }
-
+  
+    
 
         $gradebook_grade->setGradebookId($gradebook_id);
         if (!empty($actual_grade) || (int)$actual_grade === 0) {
@@ -448,8 +448,10 @@ class ilLPGradebookGrade extends ilLPGradebook
         }
        
         if ($gradebook_grade->getRecentlyCreated()) {
-            $gradebook_grade->setLastUpdate(date("Y-m-d H:i:s"));
-            $gradebook_grade->save();
+            if($actual_grade !== '') {
+                $gradebook_grade->setLastUpdate(date("Y-m-d H:i:s"));
+                $gradebook_grade->save();
+            }
         } else {
             if ($update) {
                 if ($revision_object['lp_type'] !== 0) {

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
@@ -137,14 +137,15 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
 
         $my_tpl->setVariable("LPTYPE", $this->lng->txt('gradebook_lptype'));
         $my_tpl->setVariable("DEPTH", $this->lng->txt('gradebook_depth'));
-        $my_tpl->setVariable("WEIGHT", $this->lng->txt('gradebook_weight'));
-        $my_tpl->setVariable("ACTUAL", $this->lng->txt('gradebook_actual'));
-        $my_tpl->setVariable("ADJUSTED", $this->lng->txt('gradebook_adjusted'));
+        $my_tpl->setVariable("WEIGHT", $this->lng->txt('gradebook_weight') . ' %');
+        $my_tpl->setVariable("ACTUAL", $this->lng->txt('gradebook_actual') . ' %');
+        $my_tpl->setVariable("ADJUSTED", $this->lng->txt('gradebook_adjusted') . ' %');
         $my_tpl->setVariable("STATUS", $this->lng->txt('gradebook_status'));
         $my_tpl->setVariable("OBJECT", $this->lng->txt('gradebook_object'));
         $my_tpl->setVariable("TITLE", $this->lng->txt('gradebook_title'));
         $my_tpl->setVariable("GRADED_ON", $this->lng->txt('gradebook_graded_on'));
         $my_tpl->setVariable("GRADED_BY", $this->lng->txt('gradebook_graded_by'));
+        $my_tpl->setVariable('LEGEND', ilLearningProgressBaseGUI::__getLegendHTML());
 
         $options = $this->buildParticipantsOptions();
         $revisions = $this->buildGradebookVersionsOptions();
@@ -154,6 +155,7 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
         $my_tpl->setVariable("USER_OPTIONS", $options);
 
         $my_tpl->setVariable("GRADEBOOK_REVISIONS", $revisions);
+
 
         $this->tpl->setContent($my_tpl->get());
     }
@@ -189,8 +191,8 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
             $tableHTML .= '<td>' . $object['student_name'] . '</td>';
             $tableHTML .= '<td>' . $object['login'] . '</td>';
             $tableHTML .= '<td>' . $object['revision'] . '</td>';
-            $tableHTML .= '<td>' . $object['overall_grade'] . '</td>';
-            $tableHTML .= '<td>' . $object['adjusted_grade'] . '</td>';
+            $tableHTML .= '<td>' . $object['overall_grade'] . '%</td>';
+            $tableHTML .= '<td>' . $object['adjusted_grade'] . '%</td>';
             $tableHTML .= '<td>' . $object['progress'] . '%</td>';
             $tableHTML .= '<td><img title="' . ilLearningProgressBaseGUI::_getStatusText($object['status']) . '" alt="' . ilLearningProgressBaseGUI::_getStatusText($object['status']) . '" src="' . ilLearningProgressBaseGUI::_getImagePathForStatus($object['status']) . '"></td>';
             $tableHTML .= '</tr>';
@@ -241,9 +243,9 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
             $tableHTML .= '<tr>';
             $tableHTML .= '<td>' . $span . '</td>';
             $tableHTML .= '<td>' . $data['placement_depth'] . '</td>';
-            $tableHTML .= '<td>' . $data['weight'] . '</td>';
-            $tableHTML .= '<td>' . $data['actual'] . '</td>';
-            $tableHTML .= '<td>' . $data['adjusted'] . '</td>';
+            $tableHTML .= '<td>' . $data['weight'] . '%</td>';
+            $tableHTML .= '<td>' . $data['actual'] . '%</td>'; 
+            $tableHTML .= '<td>' . $data['adjusted'] . '%</td>';
             $tableHTML .= '<td><img title="' . ilLearningProgressBaseGUI::_getStatusText($data['status']) . '" alt="' . ilLearningProgressBaseGUI::_getStatusText($data['status']) . '" src="' . ilLearningProgressBaseGUI::_getImagePathForStatus($data['status']) . '"></td>';
             $tableHTML .= '<td> <img alt="' . $data['type_Alt'] . '" title="' . $data['type_Alt'] . '" src="./templates/default/images/icon_' . $data['type'] . '.svg" class="ilListItemIcon"></td>';
             $tableHTML .= '<td>' . $data['title'] . '</td>';

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
@@ -175,7 +175,7 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
 
 
         $my_tpl->setVariable("STUDENT_NAME", $this->lng->txt('gradebook_student'));
-        $my_tpl->setVariable("STUDENT_NAME", $this->lng->txt('login'));
+        $my_tpl->setVariable("LOGIN", $this->lng->txt('login'));
         $my_tpl->setVariable("REVISION", $this->lng->txt('gradebook_revision'));
         $my_tpl->setVariable("OVERALL", $this->lng->txt('gradebook_overall_grade'));
         $my_tpl->setVariable("ADJUSTED", $this->lng->txt('gradebook_adjusted_grade'));

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
@@ -151,10 +151,10 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
         $revisions = $this->buildGradebookVersionsOptions();
 
         $my_tpl->setVariable("OVERALL_STATUS", $this->lng->txt('gradebook_overall_status') . ' : ');
-
         $my_tpl->setVariable("USER_OPTIONS", $options);
-
         $my_tpl->setVariable("GRADEBOOK_REVISIONS", $revisions);
+
+        
 
 
         $this->tpl->setContent($my_tpl->get());
@@ -215,6 +215,10 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
 
         $my_tpl->setVariable("ADJUSTED_GRADE", $this->lng->txt('gradebook_adjusted_grade') . ' ' .
             $this->user_grade_data['overall'][0]['adjusted_grade'] . '%');
+
+         $my_tpl->setVariable("PASSING_GRADE", $this->lng->txt('gradebook_passing_grade') . ' ' .
+            $this->user_grade_data['passing_grade'] . '%'); 
+
         $my_tpl->setVariable("OVERALL_PROGRESS", $this->lng->txt('gradebook_overall_progress') . ' ' .
             $this->user_grade_data['overall'][0]['progress'] . '%');
         $my_tpl->setVariable("LPTYPE", $this->lng->txt('gradebook_lptype'));

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
@@ -172,8 +172,6 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
 
         $my_tpl->setVariable("ALL_GRADES", $this->lng->txt('gradebook_all_grades'));
 
-        $my_tpl->setVariable("AVERAGE_PROGRESS", $this->lng->txt('gradebook_average_progress') . ': ' .
-            $this->participants_data['average_progress'] . '%');
 
 
         $my_tpl->setVariable("STUDENT_NAME", $this->lng->txt('gradebook_student'));

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookGradeGUI.php
@@ -145,7 +145,7 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
         $my_tpl->setVariable("TITLE", $this->lng->txt('gradebook_title'));
         $my_tpl->setVariable("GRADED_ON", $this->lng->txt('gradebook_graded_on'));
         $my_tpl->setVariable("GRADED_BY", $this->lng->txt('gradebook_graded_by'));
-        $my_tpl->setVariable('LEGEND', ilLearningProgressBaseGUI::__getLegendHTML());
+        $my_tpl->setVariable('LEGEND', $this->__getLegendHTML());
 
         $options = $this->buildParticipantsOptions();
         $revisions = $this->buildGradebookVersionsOptions();
@@ -158,6 +158,31 @@ class ilLPGradebookGradeGUI extends ilLPGradebookGUI
 
 
         $this->tpl->setContent($my_tpl->get());
+    }
+
+    public function __getLegendHTML()
+    {
+
+        $tpl = new ilTemplate("tpl.lp_gradebook_legend.html", true, true, "Services/Tracking");
+        $tpl->setVariable(
+            "TXT_MARK_GRADEBOOK",
+            $this->lng->txt("gradebook_mark_gradebook")
+        );
+        $tpl->setVariable(
+            "TXT_MARK_CHILDREN",
+            $this->lng->txt("gradebook_mark_children")
+        );
+        $tpl->setVariable(
+            "TXT_MARK_AUTOMATED",
+            $this->lng->txt("gradebook_mark_automated")
+        );
+
+        include_once "Services/UIComponent/Panel/classes/class.ilPanelGUI.php";
+        $panel = ilPanelGUI::getInstance();
+        $panel->setPanelStyle(ilPanelGUI::PANEL_STYLE_SECONDARY);
+        $panel->setBody($tpl->get());
+
+        return $panel->getHTML();
     }
 
     /**

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookWeightGUI.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookWeightGUI.php
@@ -81,13 +81,23 @@ class ilLPGradebookWeightGUI extends ilLPGradebookGUI
         $this->tpl->addJavascript('./Services/Tracking/js/ilGradebookWeight.js');
         $sortableIndex = 1;
 
-        $_POST["item_id"];
-
         $gradeBookHTML = $this->makeList($this->gradebook_data, $sortableIndex);
+        if(!is_null($this->revision_id)) {
+           foreach ($this->versions as $version) {
+                if ($version->getRevisionId() == $this->revision_id) {
+                        $passing_grade = $version->getPassingGrade();
+                }
+            }
+        } else {
+            $version = reset($this->versions);
+            $passing_grade = $version->getPassingGrade();
+        }
+
         $versions = $this->buildGradebookVersionsOptions();
 
         $my_tpl->setVariable("LOADED_GRADEBOOKS", $versions);
         $my_tpl->setVariable("GRADEBOOK", $gradeBookHTML);
+        $my_tpl->setVariable("PASSING_GRADE_VALUE", $passing_grade ? $passing_grade : 0);
 
         $this->tpl->setContent($my_tpl->get());
     }

--- a/Services/Tracking/classes/gradebook/class.ilLPGradebookWeightGUI.php
+++ b/Services/Tracking/classes/gradebook/class.ilLPGradebookWeightGUI.php
@@ -80,7 +80,7 @@ class ilLPGradebookWeightGUI extends ilLPGradebookGUI
         $this->tpl->addCss('./Services/Tracking/css/ilGradebook.css');
         $this->tpl->addJavascript('./Services/Tracking/js/ilGradebookWeight.js');
         $sortableIndex = 1;
-
+        
         $gradeBookHTML = $this->makeList($this->gradebook_data, $sortableIndex);
         if(!is_null($this->revision_id)) {
            foreach ($this->versions as $version) {
@@ -89,8 +89,10 @@ class ilLPGradebookWeightGUI extends ilLPGradebookGUI
                 }
             }
         } else {
-            $version = reset($this->versions);
-            $passing_grade = $version->getPassingGrade();
+            if($version = reset($this->versions) ) {
+                //if there is a previous version.
+                $passing_grade = $version->getPassingGrade();
+            } 
         }
 
         $versions = $this->buildGradebookVersionsOptions();

--- a/Services/Tracking/classes/gradebook/config/class.ilGradebookRevisionConfig.php
+++ b/Services/Tracking/classes/gradebook/config/class.ilGradebookRevisionConfig.php
@@ -339,16 +339,17 @@ class ilGradebookRevisionConfig extends ActiveRecord {
                 'gradebook_id'=>$this->gradebook_id])->where(['type'=>$this->containerTypes],'IN')
             ->where(['object_activated'=>1],'=');
 
+     
         //foreach of the ogroups make sure it has weighted objects under it and
         //the the user is actually a member.
         foreach($objects_arr = $objects->getArray() as $key=>&$object) {
             $children = self::getAllChildObjects($object['id']);
-            if($object['type'] == 'grp'){
+            if($object['object_data_type'] == 'grp'){
                 $participants = ilParticipants::getInstanceByObjId($object['obj_id']);
                 if(count($children)==0 || !$participants->isMember($usr_id)){
                     unset($objects_arr[$key]);
                 }
-            }elseif(in_array($object['type'],['cat','fold'])){
+            }elseif(in_array($object['object_data_type'],['cat','fold'])){
                 if(count($children)==0){
                     unset($objects_arr[$key]);
                 }

--- a/Services/Tracking/classes/gradebook/config/class.ilGradebookRevisionConfig.php
+++ b/Services/Tracking/classes/gradebook/config/class.ilGradebookRevisionConfig.php
@@ -57,6 +57,15 @@ class ilGradebookRevisionConfig extends ActiveRecord {
      * @db_fieldtype    integer
      * @db_length       4
      */
+    protected $passing_grade = null;
+
+    /**
+     * @var int
+     *
+     * @db_has_field    true
+     * @db_fieldtype    integer
+     * @db_length       4
+     */
     protected $owner = null;
 
 
@@ -152,6 +161,23 @@ class ilGradebookRevisionConfig extends ActiveRecord {
     {
         $this->owner = $owner;
     }
+
+    /**
+     * @return int
+     */
+    public function getPassingGrade()
+    {
+        return $this->passing_grade;
+    }
+
+    /**
+     * @param int $passing_grade
+     */
+    public function setPassingGrade($passing_grade)
+    {
+        $this->passing_grade = $passing_grade;
+    }
+
 
     /**
      * @return int

--- a/Services/Tracking/css/ilGradebook.css
+++ b/Services/Tracking/css/ilGradebook.css
@@ -249,7 +249,8 @@
 #gradebookContainer .btn-success
 {
     color: #fff;
-    background-color: #6ea03c;
+    background-color: #4b8512;
+    font-weight: bold;
 }
 
 

--- a/Services/Tracking/js/ilGradebookGrade.js
+++ b/Services/Tracking/js/ilGradebookGrade.js
@@ -81,7 +81,7 @@ $(function() {
                                 }
                                 tbody+='</td>';
                             }
-
+                            console.table(this);
                             tbody += '<td>'+((this.placement_depth) ? this.placement_depth: '')+'</td>';
                             tbody += '<td>'+((this.weight) ? this.weight : '')+'</td>';
                             tbody += '<td>'+ ( this.lp_type == 0 || this.is_gradeable == 0 ? ((this.actual) ? this.actual : '') : '<input class="actual" type="text" value="'+((this.actual) ? this.actual : '')+'">')+  '</td>';
@@ -99,7 +99,7 @@ $(function() {
                             tbody += '<td><img alt="'+this.type_Alt+'" title="'+this.type_Alt+'" src="./templates/default/images/icon_'+this.type+'.svg" class="ilListItemIcon"></td>';
                             tbody += '<td><a target="_blank" href="'+this.url+'">'+this.title+'</a></td>';
                             tbody += '<td>'+((this.graded_on) ? this.graded_on : '')+'</td>';
-                            tbody += '<td>'+((this.graded_by) ? this.graded_by : '')+'</td>';
+                            tbody += '<td>'+((this.graded_by && this.is_gradeable) ? this.graded_by : '')+'</td>';
                             tbody += '</tr>';
                         });
                         $('#grade-table tbody').html(tbody);

--- a/Services/Tracking/js/ilGradebookGrade.js
+++ b/Services/Tracking/js/ilGradebookGrade.js
@@ -122,30 +122,10 @@ $(function() {
                         }
 
 
-                        var courseStatusTop = '<img title="'+imgAlt+'" alt="'+imgAlt+'" src="'+overall_data['img']+'"/><select id="overallStatusTop" class="obj-status form-control">';
-                        if(overall_data['status']==0){
-                            courseStatusTop += "<option value='0' "+(overall_data['status'] == 0 ? "selected='selected'" : '')+">Not Attempted</option>";
-                        }
-                        courseStatusTop += "<option value='1' "+(overall_data['status'] == 1 ? "selected='selected'" : '')+">In Progress</option>";
-                        courseStatusTop += "<option value='2' "+(overall_data['status'] == 2 ? "selected='selected'" : '')+">Passed</option>";
-                        courseStatusTop += "<option value='3' "+(overall_data['status'] == 3 ? "selected='selected'" : '')+">Failed</option>";
-                        courseStatusTop += '</select>';
-
-
-                        var courseStatusBottom = '<img title="'+imgAlt+'" alt="'+imgAlt+'" src="'+overall_data['img']+'"/><select id="overallStatus" class="obj-status form-control">';
-                        if(overall_data['status']==0){
-                            courseStatusBottom += "<option value='0' "+(overall_data['status'] == 0 ? "selected='selected'" : '')+">Not Attempted</option>";
-                        }
-                        courseStatusBottom += "<option value='1' "+(overall_data['status'] == 1 ? "selected='selected'" : '')+">In Progress</option>";
-                        courseStatusBottom += "<option value='2' "+(overall_data['status'] == 2 ? "selected='selected'" : '')+">Passed</option>";
-                        courseStatusBottom += "<option value='3' "+(overall_data['status'] == 3 ? "selected='selected'" : '')+">Failed</option>";
-                        courseStatusBottom += '</select>';
-
-
+                        var courseStatusTop = '<img title="'+imgAlt+'" alt="'+imgAlt+'" src="'+overall_data['img']+'"/>';
+            
                         $('#courseStatusTop span').html(courseStatusTop);
                         $('#saveButtonTop').html('<input class="btn btn-default btn-sm" type="button" id="saveGradeTop" value="Update Status">');
-
-                        $('#courseStatusBottom').html('<div>Student Overall Status</div>'+courseStatusBottom);
                         $('#saveButtonBottom').html('<input class="btn btn-default btn-sm" type="button" id="saveGradeBottom" value="Save">');
                     }
                     else

--- a/Services/Tracking/js/ilGradebookWeight.js
+++ b/Services/Tracking/js/ilGradebookWeight.js
@@ -33,6 +33,7 @@ $(function() {
         });
 
         $(classList).sortable({
+            cursor: "grabbing",
             opacity: 0.5,
             placeholder: "ui-state-highlight",
             update: function (event, ui) {

--- a/Services/Tracking/js/ilGradebookWeight.js
+++ b/Services/Tracking/js/ilGradebookWeight.js
@@ -311,16 +311,29 @@ $(function() {
             $('.alert').hide();
             var flag = true;
 
-            //console.log('grade sections:');
-            //console.log(gradeSections);
-            //console.log('~~~~~~~~');
-
             $.each( gradeSections, function() {
                 var result = gradeCheck(this);
                 if(result == false){
                     flag = false;
                 }
             });
+
+            var passing_grade = $('#passing_grade').val();
+
+            //if passing grade was not sent in as a number.
+            if(isNaN(passing_grade)){
+                $('.alert-danger').html('Passing Grade is not a number');
+                $('.alert-danger').show().focus();
+                return;
+             }
+
+             //if passing grade is greater than 100 or less than 0.
+             if(passing_grade > 100 || passing_grade < 0 ) {
+                $('.alert-danger').html('Passing Grade must be between 0 - 100 %');
+                $('.alert-danger').show().focus();
+                return;
+             }
+
 
             if(flag == false) {
                 $('.alert-danger').html('Issue with weight');

--- a/Services/Tracking/js/ilGradebookWeight.js
+++ b/Services/Tracking/js/ilGradebookWeight.js
@@ -352,13 +352,14 @@ $(function() {
                     out.push(processOneLi($(this)));
                 });
 
+                var passing_grade = $( "#passing_grade" ).val();
+
                 var formData = {
                     'action'  : 'saveGradebookWeight',
                     'nodes'  : out,
-                    'ref_id': params['ref_id']
+                    'ref_id': params['ref_id'],
+                    'passing_grade': passing_grade
                 };
-
-                console.log(formData);
 
                 $.ajax({
                     type: "POST",

--- a/Services/Tracking/templates/default/tpl.lp_gradebook_course_participants.html
+++ b/Services/Tracking/templates/default/tpl.lp_gradebook_course_participants.html
@@ -13,11 +13,6 @@
             <h3 class="all-grades">{ALL_GRADES}</h3>
         </div>
     </div>
-    <div class="col-md-12 row course-participants">
-        <div  class="col-md-3 col-md-offset-1 avg-grade">
-            <h2 class="ilHeader">{AVERAGE_PROGRESS}</h2>
-        </div>
-    </div>
     <h3 class="ilHeader"><a name=""></a>{HEADER}</h3>
 </div>
 

--- a/Services/Tracking/templates/default/tpl.lp_gradebook_grade.html
+++ b/Services/Tracking/templates/default/tpl.lp_gradebook_grade.html
@@ -122,6 +122,6 @@
 
     </div></div>
 </div>
-
+<div style="margin-top:20px;">{LEGEND}</div>
 </body>
 </html> 

--- a/Services/Tracking/templates/default/tpl.lp_gradebook_grade.html
+++ b/Services/Tracking/templates/default/tpl.lp_gradebook_grade.html
@@ -86,7 +86,6 @@
             {OVERALL_STATUS}
         </h2>
         <span class="pull-left"></span>
-
     </div>
 </div>
 

--- a/Services/Tracking/templates/default/tpl.lp_gradebook_grade.html
+++ b/Services/Tracking/templates/default/tpl.lp_gradebook_grade.html
@@ -86,7 +86,7 @@
             {OVERALL_STATUS}
         </h2>
         <span class="pull-left"></span>
-        <div id="saveButtonTop" ></div>
+
     </div>
 </div>
 

--- a/Services/Tracking/templates/default/tpl.lp_gradebook_legend.html
+++ b/Services/Tracking/templates/default/tpl.lp_gradebook_legend.html
@@ -1,0 +1,5 @@
+<div class="small">
+<span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>: {TXT_MARK_GRADEBOOK}<br />
+<span class="glyphicon glyphicon-lock" aria-hidden="true"></span>: {TXT_MARK_CHILDREN}<br />
+<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>: {TXT_MARK_AUTOMATED}<br />
+</div>

--- a/Services/Tracking/templates/default/tpl.lp_gradebook_student_view.html
+++ b/Services/Tracking/templates/default/tpl.lp_gradebook_student_view.html
@@ -9,11 +9,14 @@
 
 <div class="ilFormHeader">
     <div class="col-md-12 course-participants">
-        <div class="col-md-4">
+        <div class="col-md-3">
             <h3 class="all-grades">{OVERALL_GRADE}</h3>
         </div>
-        <div  class="col-md-4 text-right">
+        <div  class="col-md-3 text-right">
             <h3 class="all-grades">{OVERALL_PROGRESS}</h3>
+        </div>
+        <div  class="col-md-3 text-right">
+            <h3 class="all-grades">{PASSING_GRADE}</h3>
         </div>
     </div>
 

--- a/Services/Tracking/templates/default/tpl.lp_gradebook_weight.html
+++ b/Services/Tracking/templates/default/tpl.lp_gradebook_weight.html
@@ -19,11 +19,32 @@
     <fieldset class="ilTableFilter">
         <form action="" method="POST">
             <div class="form-group" id="il_prop_cont_title_en">
-                <select id='gradebook_select' name="revision_id" class="form-control">{LOADED_GRADEBOOKS}}</select>
+
+                <div class="col-sm-8">
+                    <div class="col-sm-4">  <select id='gradebook_select' name="revision_id" class="form-control">{LOADED_GRADEBOOKS}</select></div>
+                    <div class="col-sm-4">  <input type="submit" class="btn btn-default" id='load' value="Load"></div>
+                  
+                </div>
+
+                <div class="col-sm-4">
+                    <div class="col-sm-8">
+                        <label class="col-sm-6 col-form-label">Passing Grade</label>
+                        <div class="col-sm-6 input-group has-success has-feedback">
+                            <div class="input-group-addon">%</div>
+                            <input name="passing_grade" class="form-control" id="passing_grade" aria-describedby="passing_gradeWarningStatus" onkeyup="validate(this)" onblur="validate(this)" type="text" value="{PASSING_GRADE_VALUE}">
+                        </div>
+                    </div>
+                    <div class="col-sml-4">
+                        <input type="submit" class="btn btn-default" id='save' value="Save">
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+           
+
             </div>
             <span>
-                <input type="submit" class="btn btn-default" id='load' value="Load">
-                <input type="submit" class="btn btn-default" id='save' value="Save">
+             
             </span>
         </form>
     </fieldset>

--- a/Services/Tracking/templates/default/tpl.lp_gradebook_weight.html
+++ b/Services/Tracking/templates/default/tpl.lp_gradebook_weight.html
@@ -23,21 +23,17 @@
                 <div class="col-sm-8">
                     <div class="col-sm-4">  <select id='gradebook_select' name="revision_id" class="form-control">{LOADED_GRADEBOOKS}</select></div>
                     <div class="col-sm-4">  <input type="submit" class="btn btn-default" id='load' value="Load"></div>
-                  
                 </div>
 
                 <div class="col-sm-4">
-                    <div class="col-sm-8">
-                        <label class="col-sm-6 col-form-label">Passing Grade</label>
-                        <div class="col-sm-6 input-group has-success has-feedback">
-                            <div class="input-group-addon">%</div>
-                            <input name="passing_grade" class="form-control" id="passing_grade" aria-describedby="passing_gradeWarningStatus" onkeyup="validate(this)" onblur="validate(this)" type="text" value="{PASSING_GRADE_VALUE}">
-                        </div>
-                    </div>
-                    <div class="col-sml-4">
-                        <input type="submit" class="btn btn-default" id='save' value="Save">
+                    <label class="col-sm-6 col-form-label">Passing Grade</label>
+                    <div class="col-sm-6 input-group has-success has-feedback">
+                        <div class="input-group-addon">%</div>
+                        <input name="passing_grade" class="form-control" id="passing_grade" aria-describedby="passing_gradeWarningStatus" onkeyup="validate(this)" onblur="validate(this)" type="text" value="{PASSING_GRADE_VALUE}">
                     </div>
                 </div>
+
+               
             </div>
             <div class="form-group">
            
@@ -52,6 +48,9 @@
 
 <div id="gradebookContainer">
     {GRADEBOOK}
+</div>
+<div class="text-right">
+    <input type="submit" class="btn btn-default" id='save' value="Save">
 </div>
 
 </body>

--- a/setup/sql/dbupdate_custom.php
+++ b/setup/sql/dbupdate_custom.php
@@ -189,5 +189,13 @@ $ilDB->addTableColumn('obj_members', 'failed', array("type" => "integer", "lengt
 ?>
 
 
+<#20>
+<?php
+//
+if(!$ilDB->tableColumnExists('gradebook_revisions','passing_grade')){
+    $ilDB->addTableColumn("gradebook_revisions", "passing_grade", array("type" => "integer", "length" => 3));
+}
+?>
+
 
 


### PR DESCRIPTION
- Adds passing grades to gradebooks.
- Automatically refreshes grades when visiting any UI area.
- Removes average progress from the overall template.
- No longer can save the status for the overall course manually (determined by passing grade).
- removed item groups from being able to be graded.
- Fixes revision switching not working.

